### PR TITLE
Centralize client API calls

### DIFF
--- a/schiessmeister-client/src/api/authService.js
+++ b/schiessmeister-client/src/api/authService.js
@@ -1,0 +1,16 @@
+import { createApi } from '../utils/api';
+
+export const loginRequest = async (username, password) => {
+    const api = createApi();
+    return api.post('/authenticate/login', { username, password });
+};
+
+export const registerRequest = async (username, email, password) => {
+    const api = createApi();
+    return api.post('/authenticate/register', { username, email, password });
+};
+
+export const getSubscriptionDetails = async (competitionId) => {
+    const api = createApi();
+    return api.get(`/competition/${competitionId}/subscribe`);
+};

--- a/schiessmeister-client/src/pages/Login.jsx
+++ b/schiessmeister-client/src/pages/Login.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { API_BASE_URL } from '../utils/api';
+import { loginRequest } from '../api/authService';
 
 const Login = () => {
 	const [username, setUsername] = useState('');
@@ -13,25 +13,13 @@ const Login = () => {
 		e.preventDefault();
 		setError('');
 
-		try {
-			const response = await fetch(API_BASE_URL + '/authenticate/login', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify({ username, password })
-			});
-
-			if (!response.ok) {
-				throw new Error('Login failed');
-			}
-
-			const data = await response.json();
-			login(data.token, data.id);
-		} catch (error) {
-			setError('Invalid username or password');
-			console.error('Login error:', error);
-		}
+               try {
+                        const data = await loginRequest(username, password);
+                        login(data.token, data.id);
+                } catch (error) {
+                        setError('Invalid username or password');
+                        console.error('Login error:', error);
+                }
 	};
 
 	return (

--- a/schiessmeister-client/src/pages/PublicLeaderboard.jsx
+++ b/schiessmeister-client/src/pages/PublicLeaderboard.jsx
@@ -5,7 +5,8 @@ import * as signalR from '@microsoft/signalr';
 import JSConfetti from 'js-confetti';
 import { SHOOTING_CLASSES } from '../constants/shootingClasses';
 import '../styles/PublicLeaderboard.css';
-import { API_BASE_URL, BASE_URL } from '../utils/api';
+import { BASE_URL } from '../utils/api';
+import { getSubscriptionDetails } from '../api/authService';
 
 const LeaderboardGrid = ({ participations }) => {
 	return (
@@ -48,11 +49,10 @@ const PublicLeaderboard = () => {
 	};
 
 	useEffect(() => {
-		const setupSignalR = async () => {
-			try {
-				// First, get the subscription details
-				const response = await fetch(API_BASE_URL + `/competition/${id}/subscribe`);
-				const subscriptionDetails = await response.json();
+               const setupSignalR = async () => {
+                        try {
+                                // First, get the subscription details
+                                const subscriptionDetails = await getSubscriptionDetails(id);
 
 				// Create SignalR connection
 				connectionRef.current = new signalR.HubConnectionBuilder()

--- a/schiessmeister-client/src/pages/Register.jsx
+++ b/schiessmeister-client/src/pages/Register.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { API_BASE_URL } from '../utils/api';
+import { registerRequest, loginRequest } from '../api/authService';
 
 const Register = () => {
 	const [username, setUsername] = useState('');
@@ -14,39 +14,14 @@ const Register = () => {
 		e.preventDefault();
 		setError('');
 
-		try {
-			const response = await fetch(API_BASE_URL + '/authenticate/register', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify({ username, email, password })
-			});
-
-			if (!response.ok) {
-				const errorData = await response.json();
-				throw new Error(errorData || 'Registration failed');
-			}
-
-			// After successful registration, automatically log in
-			const loginResponse = await fetch(API_BASE_URL + '/authenticate/login', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify({ username, password })
-			});
-
-			if (!loginResponse.ok) {
-				throw new Error('Registration successful but login failed');
-			}
-
-			const data = await loginResponse.json();
-			login(data.token, data.id);
-		} catch (error) {
-			setError(error.message || 'Registration failed');
-			console.error('Registration error:', error);
-		}
+               try {
+                        await registerRequest(username, email, password);
+                        const data = await loginRequest(username, password);
+                        login(data.token, data.id);
+                } catch (error) {
+                        setError(error.message || 'Registration failed');
+                        console.error('Registration error:', error);
+                }
 	};
 
 	return (


### PR DESCRIPTION
## Summary
- extract login/register/subscription requests into a new `authService`
- use authService in Login, Register and PublicLeaderboard pages to avoid direct `fetch` usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing React and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_684860d2fbe88322a54cff6eb69ecab6