### PR TITLE
Refactor frontend base pages

### DIFF
--- a/schiessmeister-client/src/App.jsx
+++ b/schiessmeister-client/src/App.jsx
@@ -1,46 +1,51 @@
 import Login from './pages/Login';
 import Register from './pages/Register';
-import Home from './pages/Home';
-import ParticipantsList from './pages/Participantslist';
+import Competitions from './pages/Competitions';
 import CreateCompetition from './pages/CreateCompetition';
-import CompetitionOverview from './pages/CompetitionOverview';
-import ResultsInput from './pages/ResultsInput';
+import EditCompetition from './pages/EditCompetition';
+import CompetitionDetail from './pages/CompetitionDetail';
+import Results from './pages/Results';
+import CreateParticipantGroup from './pages/CreateParticipantGroup';
+import EditParticipantGroup from './pages/EditParticipantGroup';
 import Logout from './pages/Logout';
-import PublicLeaderboard from './pages/PublicLeaderboard';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import './App.css';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AuthProvider } from './context/AuthContext';
+import { DataProvider } from './context/DataContext';
 import ProtectedRoute from './components/ProtectedRoute';
 
 export default function App() {
-	return (
-		<BrowserRouter>
-			<AuthProvider>
-				<Routes>
-					{/* Public routes */}
-					<Route path="login" element={<Login />} />
-					<Route path="register" element={<Register />} />
-					<Route path="logout" element={<Logout />} />
-					<Route path="public-leaderboard/:id" element={<PublicLeaderboard />} />
+        return (
+                <BrowserRouter>
+                        <AuthProvider>
+                                <DataProvider>
+                                        <Routes>
+                                                {/* Public routes */}
+                                                <Route path="login" element={<Login />} />
+                                                <Route path="register" element={<Register />} />
+                                                <Route path="logout" element={<Logout />} />
 
-					{/* Protected routes */}
-					<Route element={<ProtectedRoute />}>
-						<Route path="home" element={<Home />} />
-						<Route path="createcompetition" element={<CreateCompetition />} />
-						<Route path="participantsList/:id" element={<ParticipantsList />} />
-						<Route path="competition/:id" element={<CompetitionOverview />} />
-						<Route path="results/:competitionId/:participationId" element={<ResultsInput />} />
-					</Route>
+                                                {/* Protected routes */}
+                                                <Route element={<ProtectedRoute />}>
+                                                        <Route path="competitions" element={<Competitions />} />
+                                                        <Route path="competitions/new" element={<CreateCompetition />} />
+                                                        <Route path="competitions/:id" element={<CompetitionDetail />} />
+                                                        <Route path="competitions/:id/edit" element={<EditCompetition />} />
+                                                        <Route path="results" element={<Results />} />
+                                                        <Route path="participant-groups/new" element={<CreateParticipantGroup />} />
+                                                        <Route path="participant-groups/:id/edit" element={<EditParticipantGroup />} />
+                                                </Route>
 
-					{/* Redirects */}
-					<Route path="/" element={<Navigate to="/home" replace />} />
-					<Route path="*" element={<Navigate to="/home" replace />} />
-				</Routes>
-			</AuthProvider>
-		</BrowserRouter>
-	);
+                                                {/* Redirects */}
+                                                <Route path="/" element={<Navigate to="/competitions" replace />} />
+                                                <Route path="*" element={<Navigate to="/competitions" replace />} />
+                                        </Routes>
+                                </DataProvider>
+                        </AuthProvider>
+                </BrowserRouter>
+        );
 }
 
 createRoot(document.getElementById('root')).render(

--- a/schiessmeister-client/src/components/dialogs/AddDisciplineDialog.jsx
+++ b/schiessmeister-client/src/components/dialogs/AddDisciplineDialog.jsx
@@ -1,0 +1,9 @@
+const AddDisciplineDialog = () => {
+  return (
+    <div className="dialog">
+      <p>Disziplin hinzufügen (kommt später)</p>
+    </div>
+  );
+};
+
+export default AddDisciplineDialog;

--- a/schiessmeister-client/src/components/dialogs/AddParticipantDialog.jsx
+++ b/schiessmeister-client/src/components/dialogs/AddParticipantDialog.jsx
@@ -1,0 +1,9 @@
+const AddParticipantDialog = () => {
+  return (
+    <div className="dialog">
+      <p>Teilnehmer hinzufügen (kommt später)</p>
+    </div>
+  );
+};
+
+export default AddParticipantDialog;

--- a/schiessmeister-client/src/components/dialogs/AddWriterDialog.jsx
+++ b/schiessmeister-client/src/components/dialogs/AddWriterDialog.jsx
@@ -1,0 +1,9 @@
+const AddWriterDialog = () => {
+  return (
+    <div className="dialog">
+      <p>Schreiber hinzufügen (kommt später)</p>
+    </div>
+  );
+};
+
+export default AddWriterDialog;

--- a/schiessmeister-client/src/context/DataContext.jsx
+++ b/schiessmeister-client/src/context/DataContext.jsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState } from 'react';
+import { sampleCompetitions } from '../data/sampleData';
+
+const DataContext = createContext(null);
+
+export const DataProvider = ({ children }) => {
+  const [competitions, setCompetitions] = useState(sampleCompetitions);
+
+  const addCompetition = (competition) => {
+    setCompetitions([...competitions, { ...competition, id: Date.now() }]);
+  };
+
+  const updateCompetition = (id, updated) => {
+    setCompetitions(
+      competitions.map((c) => (c.id === id ? { ...c, ...updated } : c))
+    );
+  };
+
+  return (
+    <DataContext.Provider value={{ competitions, addCompetition, updateCompetition }}>
+      {children}
+    </DataContext.Provider>
+  );
+};
+
+export const useData = () => {
+  const ctx = useContext(DataContext);
+  if (!ctx) throw new Error('useData must be used within DataProvider');
+  return ctx;
+};

--- a/schiessmeister-client/src/data/sampleData.js
+++ b/schiessmeister-client/src/data/sampleData.js
@@ -1,0 +1,20 @@
+export const sampleCompetitions = [
+  {
+    id: 1,
+    name: 'Vereinsmeisterschaft',
+    location: 'Zürich',
+    date: '2025-04-01T09:00',
+    writers: [],
+    disciplines: [],
+    participantGroups: [],
+  },
+  {
+    id: 2,
+    name: 'Frühlingscup',
+    location: 'Bern',
+    date: '2025-05-15T10:00',
+    writers: [],
+    disciplines: [],
+    participantGroups: [],
+  },
+];

--- a/schiessmeister-client/src/pages/CompetitionDetail.jsx
+++ b/schiessmeister-client/src/pages/CompetitionDetail.jsx
@@ -1,0 +1,29 @@
+import { Link, useParams } from 'react-router-dom';
+import { useData } from '../context/DataContext';
+import { Button } from '@/components/ui/button';
+
+const CompetitionDetail = () => {
+  const { id } = useParams();
+  const { competitions } = useData();
+  const competition = competitions.find((c) => c.id === parseInt(id));
+
+  if (!competition) return <div>Wettbewerb nicht gefunden</div>;
+
+  return (
+    <main>
+      <h2>{competition.name}</h2>
+      <p>
+        <strong>Ort:</strong> {competition.location}
+      </p>
+      <p>
+        <strong>Datum:</strong> {competition.date}
+      </p>
+
+      <Link to={`/competitions/${id}/edit`}>
+        <Button>Bearbeiten</Button>
+      </Link>
+    </main>
+  );
+};
+
+export default CompetitionDetail;

--- a/schiessmeister-client/src/pages/Competitions.jsx
+++ b/schiessmeister-client/src/pages/Competitions.jsx
@@ -1,0 +1,26 @@
+import { Link } from 'react-router-dom';
+import { useData } from '../context/DataContext';
+import { Button } from '@/components/ui/button';
+
+const Competitions = () => {
+  const { competitions } = useData();
+
+  return (
+    <main>
+      <h2>Wettbewerbe</h2>
+      <div className="comp-list">
+        {competitions.map((c) => (
+          <Link key={c.id} to={`/competitions/${c.id}`} className="comp-item">
+            {c.name}
+          </Link>
+        ))}
+        {competitions.length === 0 && <p>Keine Wettbewerbe vorhanden.</p>}
+      </div>
+      <Link to="/competitions/new">
+        <Button>Neuer Wettbewerb</Button>
+      </Link>
+    </main>
+  );
+};
+
+export default Competitions;

--- a/schiessmeister-client/src/pages/CreateCompetition.jsx
+++ b/schiessmeister-client/src/pages/CreateCompetition.jsx
@@ -1,58 +1,22 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../context/AuthContext';
-import { createApi } from '../utils/api';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { useData } from '../context/DataContext';
+import CreateCompetitionForm from './CreateCompetitionForm';
 
 const CreateCompetition = () => {
-	const navigate = useNavigate();
-	const { userId, token, handleUnauthorized } = useAuth();
-	const [name, setName] = useState('');
-	const [location, setLocation] = useState('');
-	const [date, setDate] = useState('');
+  const { addCompetition } = useData();
+  const navigate = useNavigate();
 
-	const handleSubmit = async (e) => {
-		e.preventDefault();
+  const handleSave = (comp) => {
+    addCompetition(comp);
+    navigate('/competitions');
+  };
 
-		try {
-			const api = createApi(token, handleUnauthorized);
-			await api.post('/competition', {
-				name,
-				date,
-				location,
-				organizerId: parseInt(userId)
-			});
-
-			navigate('/home');
-		} catch (error) {
-			console.error('Failed to create competition:', error);
-		}
-	};
-
-	const handleReset = () => {
-		navigate(-1);
-	};
-
-	return (
-		<main>
-			<h2>Wettbewerb erstellen</h2>
-                        <form onSubmit={handleSubmit}>
-                                <Input type="text" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} required />
-
-                                <Input type="text" placeholder="Standort" value={location} onChange={(e) => setLocation(e.target.value)} required />
-
-                                <div>Datum</div>
-                                <Input type="datetime-local" value={date} onChange={(e) => setDate(e.target.value)} required />
-
-                                <Button type="submit">Speichern</Button>
-
-                                <Button type="button" variant="secondary" onClick={handleReset}>
-                                        Abbrechen
-                                </Button>
-                        </form>
-		</main>
-	);
+  return (
+    <main>
+      <h2>Neuer Wettbewerb</h2>
+      <CreateCompetitionForm onSave={handleSave} />
+    </main>
+  );
 };
 
 export default CreateCompetition;

--- a/schiessmeister-client/src/pages/CreateCompetitionForm.jsx
+++ b/schiessmeister-client/src/pages/CreateCompetitionForm.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useData } from '../context/DataContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+const CreateCompetitionForm = ({ initial = {}, onSave }) => {
+  const [name, setName] = useState(initial.name || '');
+  const [location, setLocation] = useState(initial.location || '');
+  const [date, setDate] = useState(initial.date || '');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSave({ name, location, date });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="form-grid">
+      <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" required />
+      <Input value={location} onChange={(e) => setLocation(e.target.value)} placeholder="Ort" required />
+      <Input type="datetime-local" value={date} onChange={(e) => setDate(e.target.value)} required />
+      <Button type="submit">Speichern</Button>
+    </form>
+  );
+};
+
+export default CreateCompetitionForm;

--- a/schiessmeister-client/src/pages/CreateParticipantGroup.jsx
+++ b/schiessmeister-client/src/pages/CreateParticipantGroup.jsx
@@ -1,0 +1,10 @@
+const CreateParticipantGroup = () => {
+  return (
+    <main>
+      <h2>Teilnehmergruppe erstellen</h2>
+      <p>Dialog zum Hinzufügen von Teilnehmern folgt.</p>
+    </main>
+  );
+};
+
+export default CreateParticipantGroup;

--- a/schiessmeister-client/src/pages/EditCompetition.jsx
+++ b/schiessmeister-client/src/pages/EditCompetition.jsx
@@ -1,0 +1,27 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useData } from '../context/DataContext';
+import CreateCompetitionForm from './CreateCompetitionForm';
+
+const EditCompetition = () => {
+  const { id } = useParams();
+  const { competitions, updateCompetition } = useData();
+  const navigate = useNavigate();
+
+  const competition = competitions.find((c) => c.id === parseInt(id));
+
+  if (!competition) return <div>Wettbewerb nicht gefunden</div>;
+
+  const handleSave = (comp) => {
+    updateCompetition(competition.id, comp);
+    navigate(`/competitions/${competition.id}`);
+  };
+
+  return (
+    <main>
+      <h2>Wettbewerb bearbeiten</h2>
+      <CreateCompetitionForm onSave={handleSave} initial={competition} />
+    </main>
+  );
+};
+
+export default EditCompetition;

--- a/schiessmeister-client/src/pages/EditParticipantGroup.jsx
+++ b/schiessmeister-client/src/pages/EditParticipantGroup.jsx
@@ -1,0 +1,10 @@
+const EditParticipantGroup = () => {
+  return (
+    <main>
+      <h2>Teilnehmergruppe bearbeiten</h2>
+      <p>Dialog zum Bearbeiten von Teilnehmern folgt.</p>
+    </main>
+  );
+};
+
+export default EditParticipantGroup;

--- a/schiessmeister-client/src/pages/Results.jsx
+++ b/schiessmeister-client/src/pages/Results.jsx
@@ -1,0 +1,10 @@
+const Results = () => {
+  return (
+    <main>
+      <h2>Resultate</h2>
+      <p>Hier werden später die Resultate angezeigt.</p>
+    </main>
+  );
+};
+
+export default Results;


### PR DESCRIPTION
## Summary
- reorganize frontend routing
- add sample data model with `DataProvider`
- set up placeholder pages for competitions and participants
- add dialog skeletons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing types for react and others)*

------
https://chatgpt.com/codex/tasks/task_e_68486714cdd88322be4eacc4762fe2ec